### PR TITLE
Configurable timeout option..

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,6 +28,10 @@ const argv = require('yargs')
             format: {
                 default: 'Letter'
             },
+            timeout: {
+                default: 30 * 1000,
+                number: true,
+            },
             landscape: {
                 boolean: true,
                 default: false
@@ -52,7 +56,9 @@ async function print(argv) {
     const url = isUrl(argv.input) ? parseUrl(argv.input).toString() : fileUrl(argv.input);
 
     console.log(`Loading ${url}`);
-    await page.goto(url);
+    await page.goto(url, {
+        timeout: argv.timeout
+    });
 
     console.log(`Writing ${argv.output}`);
     await page.pdf({


### PR DESCRIPTION
From puppeteer documentation:

https://github.com/GoogleChrome/puppeteer/blob/v0.13.0/docs/api.md#pagegotourl-options

> `timeout` <number> Maximum navigation time in milliseconds, defaults to 30 seconds, pass 0 to disable timeout.

I got an error then after [googling it](https://www.google.com.sa/search?q=error%3A+Navigation+Timeout+Exceeded%3A+30000ms+exceeded&rlz=1C1GCEU_enSA820SA820&oq=error%3A+Navigation+Timeout+Exceeded%3A+30000ms+exceeded&aqs=chrome..69i57j69i58.751034j0j4&sourceid=chrome&ie=UTF-8); it looks like it's common. and this PR will help fixing it.

Thanks for this package!

