### PR TITLE
Support --page-ranges print option

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Options:
   --display-header-footer                             [boolean] [default: false]
   --header-template                                       [string] [default: ""]
   --footer-template                                       [string] [default: ""]
+  --page-ranges                                           [string] [default: ""]
 ```
 
 ```bash

--- a/index.js
+++ b/index.js
@@ -65,6 +65,10 @@ const argv = require('yargs')
             'footer-template': {
                 string: true,
                 default: ''
+            },
+            'page-ranges': {
+                string: true,
+                default: ''
             }
         },
         handler: async argv => {
@@ -133,7 +137,8 @@ async function print(argv) {
         },
         displayHeaderFooter: argv.displayHeaderFooter,
         headerTemplate: argv.headerTemplate,
-        footerTemplate: argv.footerTemplate
+        footerTemplate: argv.footerTemplate,
+        pageRanges: argv.pageRanges
     });
 
     if (!argv.output) {


### PR DESCRIPTION
Adds `print --page-ranges` param to support the `pageRanges` pdf option:
https://github.com/puppeteer/puppeteer/blob/v5.1.0/docs/api.md#pagepdfoptions